### PR TITLE
Accept more then one role to check for permission

### DIFF
--- a/packages/activists-api/src/graphql-api.spec.ts
+++ b/packages/activists-api/src/graphql-api.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { mocked } from 'ts-jest/utils';
 import fetch from './graphql-api/client';
 import * as ActionsAPI from './graphql-api/actions';
@@ -28,11 +29,12 @@ describe('tests on api graphql', () => {
     return NotificationsAPI
       .send(input)
       .then(({ data }) => {
+        // @ts-ignore
         expect(fetchMocked).toBeCalledWith({
           query: NotificationsAPI.queries.send,
-          variables: { input }
+          variables: { input },
         });
-        expect(data).toEqual({ status: 'OK!' });
+        expect(data).toEqual({ status: "OK!" });
       });
   });
 
@@ -50,9 +52,10 @@ describe('tests on api graphql', () => {
     return ActivistsAPI
       .get_or_create(input)
       .then((activist) => {
+        // @ts-ignore
         expect(fetchMocked).toBeCalledWith({
           query: ActivistsAPI.queries.get_or_create,
-          variables: { activist: input }
+          variables: { activist: input },
         });
         expect(activist).toEqual({ ...input, id: 2 });
       });
@@ -70,9 +73,10 @@ describe('tests on api graphql', () => {
     return WidgetsAPI
       .get(widgetReturned.id)
       .then((widget) => {
+        // @ts-ignore
         expect(fetchMocked).toBeCalledWith({
           query: WidgetsAPI.queries.get,
-          variables: { widget_id: widgetReturned.id }
+          variables: { widget_id: widgetReturned.id },
         });
         expect(widget).toEqual(widgetReturned);
       });
@@ -91,9 +95,10 @@ describe('tests on api graphql', () => {
     return ActionsAPI
       .pressure(input)
       .then((activist_pressure) => {
+        // @ts-ignore
         expect(fetchMocked).toBeCalledWith({
           query: ActionsAPI.queries.pressure,
-          variables: { input }
+          variables: { input },
         });
         expect(activist_pressure).toEqual({ id: 2 });
       });
@@ -110,9 +115,10 @@ describe('tests on api graphql', () => {
     return ActionsAPI
       .pressure_sync_done(input)
       .then((activist_pressure: any) => {
+        // @ts-ignore
         expect(fetchMocked).toBeCalledWith({
           query: ActionsAPI.queries.pressure_sync_done,
-          variables: input
+          variables: input,
         });
         expect(activist_pressure).toEqual({ id: 2 });
       })

--- a/packages/redes-api/src/resolvers/create_match.ts
+++ b/packages/redes-api/src/resolvers/create_match.ts
@@ -14,8 +14,14 @@ type Args = {
   input: CreateMatch
 }
 
-const create_match = async (_: void, args: Args, context: Context): Promise<any> => {
-  const { input: { recipient, volunteer, agent, community_id } } = args
+const create_match = async (
+  _: void,
+  args: Args,
+  context: Context
+): Promise<any> => {
+  const {
+    input: { recipient, volunteer, agent, community_id },
+  } = args;
   try {
     const volunteerRes = await create_volunteer_ticket(undefined, {
       input: {
@@ -63,11 +69,11 @@ const create_match = async (_: void, args: Args, context: Context): Promise<any>
       status: "encaminhamento__realizado"
     }
 
-    return await match.create(matchTicket)
-  } catch(e) {
+    return await match.create(matchTicket);
+  } catch (e) {
     logger.error(e)
     return undefined
   }
 }
 
-export default check_user(create_match, Roles.USER)
+export default check_user(create_match, [Roles.USER, Roles.ADMIN]);

--- a/packages/redes-api/src/resolvers/create_volunteer_ticket.ts
+++ b/packages/redes-api/src/resolvers/create_volunteer_ticket.ts
@@ -84,4 +84,4 @@ const create_volunteer_ticket = async (_: void, args: Args, _context: Context): 
   }
 }
 
-export default check_user(create_volunteer_ticket, Roles.USER)
+export default check_user(create_volunteer_ticket, [Roles.USER, Roles.ADMIN]);

--- a/packages/redes-api/src/resolvers/update_recipient_ticket.ts
+++ b/packages/redes-api/src/resolvers/update_recipient_ticket.ts
@@ -79,4 +79,4 @@ const update_recipient_ticket = async (_: void, args: Args, _context: Context): 
   }
 }
 
-export default check_user(update_recipient_ticket, Roles.USER)
+export default check_user(update_recipient_ticket, [Roles.USER, Roles.ADMIN]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ importers:
       yup: ^0.30.0
   utils/permissions-utils:
     specifiers: {}
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@apollo/protobufjs/1.0.4:
     dependencies:
@@ -537,7 +537,7 @@ packages:
       jest-haste-map: 26.2.2
       jest-message-util: 26.2.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve: 26.2.2
       jest-resolve-dependencies: 26.2.2
       jest-runner: 26.2.2
       jest-runtime: 26.2.2
@@ -607,7 +607,7 @@ packages:
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
       jest-haste-map: 26.2.2
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve: 26.2.2
       jest-util: 26.2.0
       jest-worker: 26.2.1
       slash: 3.0.0
@@ -3954,7 +3954,7 @@ packages:
       jest-get-type: 26.0.0
       jest-jasmine2: 26.2.2
       jest-regex-util: 26.0.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve: 26.2.2
       jest-util: 26.2.0
       jest-validate: 26.2.0
       micromatch: 4.0.2
@@ -4138,7 +4138,7 @@ packages:
       integrity: sha512-XeC7yWtWmWByoyVOHSsE7NYsbXJLtJNgmhD7z4MKumKm6ET0si81bsSLbQ64L5saK3TgsHo2B/UqG5KNZ1Sp/Q==
   /jest-pnp-resolver/1.2.2_jest-resolve@26.2.2:
     dependencies:
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve: 26.2.2
     dev: true
     engines:
       node: '>=6'
@@ -4165,7 +4165,7 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-S5vufDmVbQXnpP7435gr710xeBGUFcKNpNswke7RmFvDQtmqPjPVU/rCeMlEU0p6vfpnjhwMYeaVjKZAy5QYJA==
-  /jest-resolve/26.2.2_jest-resolve@26.2.2:
+  /jest-resolve/26.2.2:
     dependencies:
       '@jest/types': 26.2.0
       chalk: 4.1.0
@@ -4178,8 +4178,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    peerDependencies:
-      jest-resolve: '*'
     resolution:
       integrity: sha512-ye9Tj/ILn/0OgFPE/3dGpQPUqt4dHwIocxt5qSBkyzxQD8PbL0bVxBogX2FHxsd3zJA7V2H/cHXnBnNyyT9YoQ==
   /jest-runner/26.2.2:
@@ -4198,7 +4196,7 @@ packages:
       jest-haste-map: 26.2.2
       jest-leak-detector: 26.2.0
       jest-message-util: 26.2.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve: 26.2.2
       jest-runtime: 26.2.2
       jest-util: 26.2.0
       jest-worker: 26.2.1
@@ -4230,7 +4228,7 @@ packages:
       jest-message-util: 26.2.0
       jest-mock: 26.2.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve: 26.2.2
       jest-snapshot: 26.2.2
       jest-util: 26.2.0
       jest-validate: 26.2.0
@@ -4265,7 +4263,7 @@ packages:
       jest-haste-map: 26.2.2
       jest-matcher-utils: 26.2.0
       jest-message-util: 26.2.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve: 26.2.2
       natural-compare: 1.4.0
       pretty-format: 26.2.0
       semver: 7.3.2

--- a/utils/permissions-utils/src/index.ts
+++ b/utils/permissions-utils/src/index.ts
@@ -18,7 +18,7 @@ export enum Roles {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const handle_check_user = ({ fetch, logger }: Options) => (next: any, role: Roles) => async (_: void, args: any, context: Context) => {
+export const handle_check_user = ({ fetch, logger }: Options) => (next: any, role: Roles | [Roles]) => async (_: void, args: any, context: Context) => {
   const get_permission = handle_get_permission({ fetch, logger });
   const { session }: Context = context;
 
@@ -27,7 +27,10 @@ export const handle_check_user = ({ fetch, logger }: Options) => (next: any, rol
     // Get permission on API-GraphQL (Hasura)
     const { permission, user } = await get_permission({ user_id: session.user_id, community_id });
     // Execute only when role is permitted from relationship between community users
-    if (permission?.role === role || user.is_admin) return next(_, args, context);
+    const roleInArray = typeof role === 'number' ? [role] : role
+    if (
+      roleInArray.includes(permission?.role) || user.is_admin
+    ) return next(_, args, context);
   }
   // Permission denied
   throw new Error('invalid_permission');


### PR DESCRIPTION
One of Mapa do Acolhimento users wasnt allowed to make matches because the role permission selected to make matches was USER (2), Mapa's user had a ADMIN (1) role in the community.

Now the `permissions-utils` accepts an array to validate the resolver permission.