### PR TITLE
Accept external_id null value

### DIFF
--- a/packages/redes-api/src/resolvers/create_match.ts
+++ b/packages/redes-api/src/resolvers/create_match.ts
@@ -23,22 +23,26 @@ const create_match = async (
     input: { recipient, volunteer, agent, community_id },
   } = args;
   try {
-    const volunteerRes = await create_volunteer_ticket(undefined, {
-      input: {
-        recipient_ticket: {
-          external_id: recipient.external_id,
-          nome_msr: recipient.nome_msr,
-          ticket_id: recipient.ticket_id,
+    const volunteerRes = await create_volunteer_ticket(
+      undefined,
+      {
+        input: {
+          recipient_ticket: {
+            external_id: recipient.external_id || null,
+            nome_msr: recipient.nome_msr,
+            ticket_id: recipient.ticket_id,
+          },
+          volunteer_user: {
+            user_id: volunteer.user_id,
+            organization_id: volunteer.organization_id,
+            name: volunteer.name,
+          },
+          agent,
+          community_id,
         },
-        volunteer_user: {
-          user_id: volunteer.user_id,
-          organization_id: volunteer.organization_id,
-          name: volunteer.name,
-        },
-        agent,
-        community_id
-      }
-    }, context)
+      },
+      context
+    );
 
     await update_recipient_ticket(undefined, {
       input: {

--- a/packages/redes-api/src/resolvers/create_volunteer_ticket.ts
+++ b/packages/redes-api/src/resolvers/create_volunteer_ticket.ts
@@ -24,7 +24,7 @@ const hasuraSchema = yup
     status: yup.string().required(),
     subject: yup.string().required(),
     description: yup.string().required(),
-    external_id: yup.number().required(),
+    external_id: yup.number().nullable(),
     custom_fields: yup
       .array()
       .of(
@@ -32,7 +32,7 @@ const hasuraSchema = yup
           .object()
           .shape({
             id: yup.number(),
-            value: yup.string().nullable()
+            value: yup.string().nullable(),
           })
           .required()
       )
@@ -47,7 +47,7 @@ const hasuraSchema = yup
     link_match: yup.string().required(),
     data_encaminhamento: yup.string().required(),
     nome_msr: yup.string().required(),
-    status_acolhimento: yup.string().required()
+    status_acolhimento: yup.string().required(),
   })
   .required();
 

--- a/packages/redes-api/src/schema/schema.graphql
+++ b/packages/redes-api/src/schema/schema.graphql
@@ -42,7 +42,7 @@ input VolunteerTicketInsertInput {
 }
 
 input RecipientTicketInsert {
-  external_id: ID!
+  external_id: ID
   nome_msr: String!
   ticket_id: ID!
 }
@@ -97,7 +97,7 @@ type CreateMatchResponse {
 }
 
 input MatchRecipient {
-  external_id: ID!
+  external_id: ID
   nome_msr: String!
   ticket_id: ID!
   organization_id: ID!

--- a/packages/redes-api/src/types/match.ts
+++ b/packages/redes-api/src/types/match.ts
@@ -9,7 +9,7 @@ export type MatchTicket = {
 
 export type CreateMatch = {
   recipient: {
-    external_id: number
+    external_id?: number
     nome_msr: string
     ticket_id: number
     organization_id: number


### PR DESCRIPTION
Not all recipient tickets have `external_id`, so the match methods shouldn't require it.