### PR TITLE
Integração com Certificados (REDIS)

### DIFF
--- a/migrations/metadata/databases/default/tables/public_form_entries.yaml
+++ b/migrations/metadata/databases/default/tables/public_form_entries.yaml
@@ -39,14 +39,3 @@ select_permissions:
     - widget_id
     filter: {}
   role: user
-event_triggers:
-- definition:
-    enable_manual: false
-    insert:
-      columns: "*"
-  name: webhooks-plip-form-mautic
-  retry_conf:
-    interval_sec: 10
-    num_retries: 0
-    timeout_sec: 60
-  webhook: http://n8n.enedina.bonde.org/webhook/plip-form-mautic

--- a/migrations/metadata/databases/default/tables/public_plip_signatures.yaml
+++ b/migrations/metadata/databases/default/tables/public_plip_signatures.yaml
@@ -65,4 +65,4 @@ event_triggers:
     interval_sec: 10
     num_retries: 0
     timeout_sec: 60
-  webhook_from_env: WEBHOOK_PLIP_SIGNATURES_MAUTIC_URL
+  webhook: "{{N8N_WEBHOOK_URL}}/plip-signatures-mautic"

--- a/migrations/metadata/databases/default/tables/public_plip_signatures.yaml
+++ b/migrations/metadata/databases/default/tables/public_plip_signatures.yaml
@@ -65,4 +65,4 @@ event_triggers:
     interval_sec: 10
     num_retries: 0
     timeout_sec: 60
-  webhook: http://n8n.enedina.bonde.org/webhook/plip-signatures-mautic
+  webhook_from_env: WEBHOOK_PLIP_SIGNATURES_MAUTIC_URL

--- a/migrations/metadata/databases/default/tables/public_plips.yaml
+++ b/migrations/metadata/databases/default/tables/public_plips.yaml
@@ -87,4 +87,4 @@ event_triggers:
     interval_sec: 10
     num_retries: 0
     timeout_sec: 60
-  webhook_from_env: WEBHOOK_PLIP_MAUTIC_URL
+  webhook: "{{N8N_WEBHOOK_URL}}/plip-mautic"

--- a/packages/domains-api/src/controllers/certificates-controller.spec.ts
+++ b/packages/domains-api/src/controllers/certificates-controller.spec.ts
@@ -74,6 +74,15 @@ describe('Certificates controller', () => {
       expect(mockCreateWildcard.mock.calls[0]).toEqual([tRouterName, request.body.event.data.new.domain_name])
     });
 
+    it('should call fetchMobilizationsByDomain', async () => {
+      const certificatesController = new CertificatesController(mockGraphQLClient);
+      await certificatesController.create(request, response);
+
+      expect(mockGraphQLClient.request.mock.calls[0][0].variables).toEqual({
+        domainName: `%${dns.domain_name}%`
+      });
+    });
+
     it('should create traefik routers for subdomains in redis', async () => {
       const mobilizations = [
         { id: 1, community_id: 2, custom_domain: `www.campaign0.${dns.domain_name}` },

--- a/packages/domains-api/src/controllers/certificates-controller.spec.ts
+++ b/packages/domains-api/src/controllers/certificates-controller.spec.ts
@@ -4,49 +4,104 @@ import CertificatesController, {
   DNSHostedZone
 } from './certificates-controller';
 
-test('should create certificate', () => {
-  // const mockReq: Request<Certificate> = {
-  //   body: {
-  //     event: {
-  //       data: {
-  //         new: {
-  //           domain: "lutarnaoecrime.org",
-  //           id: 33,
-  //         }
-  //       }
-  //     }
-  //   }
-  // };
-  const mockReq: Request<DNSHostedZone> = {
-    body: {
-      event: {
-        data: {
-          new: {
-            domain_name: "lutarnaoecrime.org",
-            id: 33,
-            community_id: 2
+describe('Certificates controller', () => {
+  // Mock de clients externos API e Redis (Padrão para todos os testes)
+  const mockGraphQLClient = {
+    request: jest.fn()
+  }
+  const mockRedisClient = {
+    connect: jest.fn(),
+    set: jest.fn(),
+    quit: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  })
+
+  describe('certificate is create', () => {
+    // Mock de entradas da função (Padrão para testes que criam certificado)
+    const request = {
+      body: {
+        event: {
+          data: {
+            new: {
+              id: 4,
+              community_id: 1,
+              domain_name: 'test.org',
+              ns_ok: true
+            }
           }
         }
       }
     }
-  };
-  // const mockData = {
-  //   dns_hosted_zones_by_pk: {
-  //     hosted_zone: 'aaa.com',
-  //     name_servers: 'aaaaa.com'
-  //   }
-  // };
-  // const mockFn = {
-  //   request: jest.fn().mockReturnValue({
-  //     data: mockData,
-  //     errors: {}
-  //   })
-  // };
-  const mRes = { status: jest.fn().mockReturnThis(), json: jest.fn(), body: mockReq.body };
+    const mockJson = jest.fn();
+    const response: any = {
+      status: jest.fn().mockImplementation(() => ({
+        json: mockJson
+      }))
+    }
 
-  const certificatesController = new CertificatesController(jest.fn(), jest.fn());
-  certificatesController.create(mockReq, mRes);
+    it('should return graphql response to action', async () => {
+      const result = {
+        id: 3,
+        dns_hosted_zone_id: request.body.event.data.new.id,
+        is_active: false,
+        community_id: request.body.event.data.new.community_id,
+        domain: 'test.org',
+      }
+  
+      // Mock de clients externos API e Redis
+      mockGraphQLClient.request.mockResolvedValue({ insert_certificates_one: result });
+  
+      const certificatesController = new CertificatesController(mockRedisClient, mockGraphQLClient);
+      await certificatesController.create(request, response);
+    
+      expect(response.status.mock.calls[0][0]).toBe(200);
+      expect(mockJson.mock.calls[0][0]).toBe(result);
+    });
+  
+    it('should create traefik routers in redis', async () => {
+      const certificatesController = new CertificatesController(mockRedisClient, mockGraphQLClient);
+      await certificatesController.create(request, response);
 
-  // expect(mRes.status).toBeCalled();
-  expect(mRes.body).toBe(mockReq.body);
-});
+      const tRouterName = `${request.body.event.data.new.id}-${request.body.event.data.new.domain_name.replace('.', '-')}`;
+
+      expect(mockRedisClient.set.mock.calls[0][0]).toEqual(`traefik/http/routers/${tRouterName}/tls`);
+      expect(mockRedisClient.set.mock.calls[0][1]).toEqual('true');
+    });
+  });
+
+  describe('certificate is not create', () => {
+    // Mock de entradas da função (Padrão para testes que não criam certificado)
+    const request = {
+      body: {
+        event: {
+          data: {
+            new: {
+              id: 4,
+              community_id: 1,
+              domain_name: 'test.org',
+              ns_ok: false
+            }
+          }
+        }
+      }
+    }
+    const mockJson = jest.fn();
+    const response: any = {
+      status: jest.fn().mockImplementation(() => ({
+        json: mockJson
+      }))
+    }
+
+    it('should return 400 when dns is not ok', async () => {
+      const certificatesController = new CertificatesController(mockRedisClient, mockGraphQLClient);
+      await certificatesController.create(request, response);
+
+      expect(response.status.mock.calls[0][0]).toEqual(402);
+      expect(mockJson.mock.calls[0][0]).toEqual({ message: 'Certificate not created because ns_ok is false.' });
+    });
+  });
+})
+

--- a/packages/domains-api/src/controllers/certificates-controller.spec.ts
+++ b/packages/domains-api/src/controllers/certificates-controller.spec.ts
@@ -1,8 +1,10 @@
-import CertificatesController, {
-  Request,
-  //  Certificate, 
-  DNSHostedZone
-} from './certificates-controller';
+const mockCreateWildcard = jest.fn();
+
+jest.mock('../redis-db/certificates', () => ({
+  createWildcard: mockCreateWildcard
+}))
+
+import CertificatesController from './certificates-controller';
 
 describe('Certificates controller', () => {
   // Mock de clients externos API e Redis (Padrão para todos os testes)
@@ -67,8 +69,7 @@ describe('Certificates controller', () => {
 
       const tRouterName = `${request.body.event.data.new.id}-${request.body.event.data.new.domain_name.replace('.', '-')}`;
 
-      expect(mockRedisClient.set.mock.calls[0][0]).toEqual(`traefik/http/routers/${tRouterName}/tls`);
-      expect(mockRedisClient.set.mock.calls[0][1]).toEqual('true');
+      expect(mockCreateWildcard.mock.calls[0]).toEqual([tRouterName, request.body.event.data.new.domain_name])
     });
   });
 

--- a/packages/domains-api/src/controllers/certificates-controller.ts
+++ b/packages/domains-api/src/controllers/certificates-controller.ts
@@ -137,7 +137,7 @@ class CertificatesController {
   private fetchCustomDomains = async (domain: string): Promise<string[]> => {
     const data: { mobilizations: Mobilization[] } = await this.graphqlClient.request({
       document: fetch_mobilizations_by_domain,
-      variables: { domain: `%${domain}%` }
+      variables: { domainName: `%${domain}%` }
     });
 
     logger.child({ data }).info('fetch_mobilizations_by_domain');

--- a/packages/domains-api/src/redis-db/certificates.spec.ts
+++ b/packages/domains-api/src/redis-db/certificates.spec.ts
@@ -1,0 +1,105 @@
+// 1. Criar um rota wildcard para o dominio principal subdomain / domain - Ex.: *.meurio.org.br meurio.org.br, auxiliomoradia.meurio.org.br
+//
+// 2. Criar uma rota para cada X subdominios com www - Ex.: www.auxiliomoradia.meurio.org.br, www.forapaes.meurio.org.br
+// X = 100
+
+const mockConnect = jest.fn();
+const mockSet = jest.fn();
+const mockQuit = jest.fn();
+
+jest.mock('./client', () => ({
+  connect: mockConnect,
+  set: mockSet,
+  quit: mockQuit
+}))
+
+import { DNSHostedZone } from "../controllers/certificates-controller";
+import { createWildcard, createRouters } from "./certificates";
+
+describe('Certificates Redis', () => {
+  const dns: DNSHostedZone = {
+    id: 1,
+    community_id: 75,
+    domain_name: 'nossas.link'
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createWildcard is successfully', () => {
+    const routerName = `${dns.id}-${dns.domain_name.replace('.', '-')}`;
+  
+    it('should open and quit connect redis', async () => {
+      await createWildcard(routerName, dns.domain_name);
+
+      expect(mockConnect.mock.calls.length).toEqual(1);
+      expect(mockQuit.mock.calls.length).toEqual(1);
+    });
+
+    it('should register wildcard in redis', async () => {
+      await createWildcard(routerName, dns.domain_name);
+
+      expect(mockSet.mock.calls[0]).toEqual([`traefik/http/routers/${routerName}/tls`, 'true']);
+      expect(mockSet.mock.calls[1]).toEqual([`traefik/http/routers/${routerName}/tls/certresolver`, 'myresolver']);
+      expect(mockSet.mock.calls[2]).toEqual([`traefik/http/routers/${routerName}/rule`, `HostRegexp(\`${dns.domain_name}\`, \`{subdomain:.+}.${dns.domain_name}\`)`]);
+      expect(mockSet.mock.calls[3]).toEqual([`traefik/http/routers/${routerName}/tls/domains/0/main`, dns.domain_name]);
+      expect(mockSet.mock.calls[4]).toEqual([`traefik/http/routers/${routerName}/tls/domains/0/sans/0`, `*.${dns.domain_name}`]);
+      expect(mockSet.mock.calls[5]).toEqual([`traefik/http/routers/${routerName}/service`, 'public@docker']);
+    });
+  });
+
+  describe('createRouters is successfully', () => {
+    const routerName = `${dns.id}-${dns.domain_name.replace('.', '-')}-www`;
+    const domainNames = [
+      `www.campanha1.${dns.domain_name}`,
+      `www.campanha2.${dns.domain_name}`,
+      `www.campanha3.${dns.domain_name}`
+    ]
+
+    it('should open and quit connect redis', async () => {
+      await createRouters(routerName, domainNames);
+
+      expect(mockConnect.mock.calls.length).toEqual(1);
+      expect(mockQuit.mock.calls.length).toEqual(1);
+    });
+
+    it('should register in redis a router with domainNames', async () => {
+      await createRouters(routerName, domainNames);
+
+      expect(mockSet.mock.calls[0]).toEqual([`traefik/http/routers/${routerName}-0/tls`, 'true']);
+      expect(mockSet.mock.calls[1]).toEqual([`traefik/http/routers/${routerName}-0/tls/certresolver`, 'myresolver']);
+      expect(mockSet.mock.calls[2]).toEqual([`traefik/http/routers/${routerName}-0/service`, 'public@docker']);
+      expect(mockSet.mock.calls[3]).toEqual([
+        `traefik/http/routers/${routerName}-0/rule`,
+        `Host(${domainNames.map((domain) => `\`${domain}\``).join(',')})`
+      ]);
+    });
+
+    it('should register in redis a router every 100 domainNames', async () => {
+      const manyDomainNames = Array.from({ length: 150 }, (_, index: number) => `www.campanha${index}.${dns.domain_name}`);
+
+      await createRouters(routerName, manyDomainNames);
+
+      console.log(mockSet.mock.calls);
+      expect(mockSet.mock.calls[0]).toEqual([`traefik/http/routers/${routerName}-0/tls`, 'true']);
+      expect(mockSet.mock.calls[1]).toEqual([`traefik/http/routers/${routerName}-1/tls`, 'true']);
+      
+      expect(mockSet.mock.calls[2]).toEqual([`traefik/http/routers/${routerName}-0/tls/certresolver`, 'myresolver']);
+      expect(mockSet.mock.calls[3]).toEqual([`traefik/http/routers/${routerName}-1/tls/certresolver`, 'myresolver']);
+      
+      expect(mockSet.mock.calls[4]).toEqual([`traefik/http/routers/${routerName}-0/service`, 'public@docker']);
+      expect(mockSet.mock.calls[5]).toEqual([`traefik/http/routers/${routerName}-1/service`, 'public@docker']);
+      
+      expect(mockSet.mock.calls[6]).toEqual([
+        `traefik/http/routers/${routerName}-0/rule`,
+        `Host(${manyDomainNames.slice(0, 100).map((domain) => `\`${domain}\``).join(',')})`
+      ]);
+      expect(mockSet.mock.calls[7]).toEqual([
+        `traefik/http/routers/${routerName}-1/rule`,
+        `Host(${manyDomainNames.slice(100, 150).map((domain) => `\`${domain}\``).join(',')})`
+      ]);
+
+    });
+  })
+});

--- a/packages/domains-api/src/redis-db/certificates.ts
+++ b/packages/domains-api/src/redis-db/certificates.ts
@@ -1,0 +1,37 @@
+import redisClient from './client';
+
+export const createWildcard = async (routerName: string, domainName: string): Promise<void> => {
+  // Open connection with redis
+  await redisClient.connect();
+  // Configure routers
+  await redisClient.set(`traefik/http/routers/${routerName}/tls`, 'true');
+  await redisClient.set(`traefik/http/routers/${routerName}/tls/certresolver`, 'myresolver');
+  await redisClient.set(`traefik/http/routers/${routerName}/rule`, `HostRegexp(\`${domainName}\`, \`{subdomain:.+}.${domainName}\`)`);
+  await redisClient.set(`traefik/http/routers/${routerName}/tls/domains/0/main`, domainName);
+  await redisClient.set(`traefik/http/routers/${routerName}/tls/domains/0/sans/0`, `*.${domainName}`);
+  await redisClient.set(`traefik/http/routers/${routerName}/service`, 'public@docker');
+  // Close connection with redis
+  await redisClient.quit();
+}
+
+export const createRouters = async (routerName: string, domainNames: string[]): Promise<void> => {
+  // Open connection with redis
+  await redisClient.connect();
+  // Configure routers
+  let cursor = Math.floor(domainNames.length / 100);
+  if (domainNames.length % 100 !== 0) cursor += 1;
+  
+
+  await Promise.all(Array.from({ length: cursor > 0 ? cursor : 1 }, async (_, index: number) => {
+    await redisClient.set(`traefik/http/routers/${routerName}-${index}/tls`, 'true');
+    await redisClient.set(`traefik/http/routers/${routerName}-${index}/tls/certresolver`, 'myresolver');
+    await redisClient.set(`traefik/http/routers/${routerName}-${index}/service`, 'public@docker');
+    await redisClient.set(
+      `traefik/http/routers/${routerName}-${index}/rule`,
+      `Host(${domainNames.slice(index * 100, (index + 1) * 100).map((domain) => `\`${domain}\``).join(',')})`
+    );
+  }))
+
+  // Close connection with redis
+  await redisClient.quit();
+}

--- a/packages/domains-api/src/routes/events-route.ts
+++ b/packages/domains-api/src/routes/events-route.ts
@@ -1,12 +1,12 @@
 // import dependencies and initialize the express router
 import express from 'express';
 import CertificatesController from '../controllers/certificates-controller';
-import redisClient from '../redis-db/client'
+// import redisClient from '../redis-db/client'
 import { client } from '../graphql-api/client';
 
 const router = express.Router();
 
-const certificatesController = new CertificatesController(redisClient, client);
+const certificatesController = new CertificatesController(client);
 
 // define routes
 router.post('/create-certificate', certificatesController.create);


### PR DESCRIPTION
- [x] Criar certificado apenas para dominios com DNS configurado (Ex.: `*.comunidade.org.br`)
- [x] Criar certificados para todos os subdominios do DNS configurado (Ex.: `www.campanha1.comunidade.org.br`)