### PR TITLE
Corrige indice para verificar e-mail duplicado de ativista

### DIFF
--- a/migrations/migrations/default/1654196415433_drop_unused_index_activists/down.sql
+++ b/migrations/migrations/default/1654196415433_drop_unused_index_activists/down.sql
@@ -1,0 +1,3 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- DROP INDEX IF EXISTS public.uniq_email_acts CASCADE;

--- a/migrations/migrations/default/1654196415433_drop_unused_index_activists/up.sql
+++ b/migrations/migrations/default/1654196415433_drop_unused_index_activists/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS public.uniq_email_acts CASCADE;


### PR DESCRIPTION
### Contexto: 
Para algumas pessoas o formulário da amazônia de pé não estava sendo subemitido. Investigamos os casos e ao tentar inserir determinados emails na tabela de ativistas  retornava um erro de duplicação de registro apesar do email não existir na tabela. 
### Solução: 
Remover o indíce duplicado do email na tabela de ativistas
 
- fix(migrations): drop index uniq_email_acts