### PR TITLE
chore: add created_at to plip permissions

### DIFF
--- a/migrations/metadata/databases/default/tables/public_plips.yaml
+++ b/migrations/metadata/databases/default/tables/public_plips.yaml
@@ -39,6 +39,7 @@ select_permissions:
   - role: anonymous
     permission:
       columns:
+        - created_at
         - expected_signatures
         - id
         - unique_identifier


### PR DESCRIPTION
- [x] Adiciona created_at da tabela plip nas permissões, para aplicar o mesmo filtro que é aplicado no metabase p/ o cálculo de ativistas