### PR TITLE
feat(notifications): add development mode using 'test' ElasticSearch credentials

### DIFF
--- a/packages/notifications/src/config.ts
+++ b/packages/notifications/src/config.ts
@@ -17,6 +17,8 @@ type Config = {
   apmSecretToken?: string
   apmServerUrl?: string
   apmServiceName?: string
+  devEnv?: boolean,
+  elasticsearchDevMode?: boolean
 }
 
 const config: Config = {
@@ -33,7 +35,9 @@ const config: Config = {
   elasticsearchPassword: process.env.ELASTICSEARCH_PASSWORD,
   apmSecretToken: process.env.ELASTIC_APM_SECRET_TOKEN,
   apmServerUrl: process.env.ELASTIC_APM_SERVER_URL,
-  apmServiceName: process.env.ELASTIC_APM_SERVICE_NAME
+  apmServiceName: process.env.ELASTIC_APM_SERVICE_NAME,
+  devEnv: process.env.NODE_ENV == 'development',
+  elasticsearchDevMode: process.env.ELASTICSEARCH_CLOUD_ID == 'test' && process.env.ELASTICSEARCH_PASSWORD == 'test'
 };
 
 export default config;

--- a/packages/notifications/src/core/elasticsearchdb.ts
+++ b/packages/notifications/src/core/elasticsearchdb.ts
@@ -4,7 +4,7 @@ import config from "../config";
 if (!config.elasticsearchCloudId) throw new Error("ELASTICSEARCH_CLOUD_ID should be environment.");
 if (!config.elasticsearchPassword) throw new Error("ELASTICSEARCH_PASSWORD should be environment.");
 
-export const client = new Client({
+export const client = new Client(config.devEnv && config.elasticsearchDevMode ? { nodes: [] } : {
   cloud: {
     id: config.elasticsearchCloudId
   },

--- a/packages/notifications/src/webhooks/index.ts
+++ b/packages/notifications/src/webhooks/index.ts
@@ -1,6 +1,6 @@
 import sendgrid from "./sendgrid";
 
-const webhhooksMap = {
+const webhooksMap = {
   "/sendgrid": sendgrid
 }
 
@@ -11,8 +11,8 @@ type MiddlewareArgs = {
 
 export const webhooks = {
   applyMiddleware: ({ app, path }: MiddlewareArgs): void => {
-    Object.keys(webhhooksMap).forEach((keyName: string) => {
-      app.post(path + keyName, webhhooksMap[keyName]);
+    Object.keys(webhooksMap).forEach((keyName: string) => {
+      app.post(path + keyName, webhooksMap[keyName]);
     })
   }
 }


### PR DESCRIPTION
This feature adds the capability to launch the Notifications API without valid `ELASTICSEARCH_CLOUD_ID` and `ELASTICSEARCH_PASSWORD` environment variables.

When `NODE_ENV=development` you have to use the `test` value for the ElasticSearch credential variables to activate the development mode:
```.env
ELASTICSEARCH_CLOUD_ID=test
ELASTICSEARCH_PASSWORD=test
```