### PR TITLE
Vizualização de indicadores de entrega desse e-mail no BONDE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 WORKDIR /usr/src/app
 

--- a/packages/activists-api/src/resolvers/action/next.spec.ts
+++ b/packages/activists-api/src/resolvers/action/next.spec.ts
@@ -121,7 +121,13 @@ describe('next proccess on BaseAction mailchimp tests', () => {
           email_from: `${opts.widget.settings.sender_name} <${opts.widget.settings.sender_email}>`,
           email_to: `${opts.activist.name} <${opts.activist.email}>`,
           subject: opts.widget.settings.email_subject,
-          body: opts.widget.settings.email_text
+          body: opts.widget.settings.email_text,
+          context: {
+            autofire: true,
+            widget_id: opts.widget.id,
+            mobilization_id: opts.widget.block.mobilization.id,
+            community_id: opts.widget.block.mobilization.community.id
+          }
         })
       });
   });
@@ -139,7 +145,13 @@ describe('next proccess on BaseAction mailchimp tests', () => {
           email_from: opts.widget.block.mobilization.community.email_template_from,
           email_to: `${opts.activist.name} <${opts.activist.email}>`,
           subject: opts.widget.settings.email_subject,
-          body: opts.widget.settings.email_text
+          body: opts.widget.settings.email_text,
+          context: {
+            autofire: true,
+            widget_id: opts.widget.id,
+            mobilization_id: opts.widget.block.mobilization.id,
+            community_id: opts.widget.block.mobilization.community.id
+          }
         })
       });
   });

--- a/packages/activists-api/src/resolvers/action/next.ts
+++ b/packages/activists-api/src/resolvers/action/next.ts
@@ -16,6 +16,13 @@ export default async <T>({ activist, widget }: IBaseAction<T>, done?: DoneAction
   }
 
   // Post-action
+  // Configurar contexto para categorizar mensagens no sendgrid
+  const context = {
+    widget_id:widget.id,
+    mobilization_id:widget.block.mobilization.id,
+    community_id:community.id,
+    autofire:true
+  }
   const { email_subject, sender_email, sender_name, email_text } = widget.settings;
 
   // TODO: Required fields to Notify "Pós-Ação"
@@ -23,7 +30,8 @@ export default async <T>({ activist, widget }: IBaseAction<T>, done?: DoneAction
     email_from: community.email_template_from,
     email_to: `${activist.name} <${activist.email}>`,
     subject: email_subject,
-    body: email_text
+    body: email_text,
+    context
   };
 
   // TODO: Thing a better place to move this code
@@ -44,7 +52,7 @@ export default async <T>({ activist, widget }: IBaseAction<T>, done?: DoneAction
 
   await NotificationsAPI.send(notifyOpts);
 
-  logger.child({ activist, widget }).info('action is done');
+  logger.child({ activist, widget, notifyOpts }).info('action is done');
 };
 
 // 0. trazer a função de processar pdf e inserir plip para remote schema

--- a/packages/notifications/src/core/mail.ts
+++ b/packages/notifications/src/core/mail.ts
@@ -1,3 +1,4 @@
+import logger, { apmAgent } from '../logger';
 import nunjucks from 'nunjucks';
 
 export interface MailSettings {
@@ -73,15 +74,31 @@ class Mail {
     }
 
     let categories: string[] = [];
-    if (context?.widget_id) {
-      categories = [...categories, `w${context?.widget_id}`]
+
+    if (!context.autofire) {
+      if (context?.widget_id) {
+        categories = [...categories, `w${context?.widget_id}`]
+      }
+      if (context?.mobilization_id) {
+        categories = [...categories, `m${context?.mobilization_id}`]
+      }
+      if (context?.community_id) {
+        categories = [...categories, `c${context?.community_id}`]
+      }
+    } else {
+      categories = [...categories, 'autofire']
+      if (context?.widget_id) {
+        categories = [...categories, `autofire-w${context?.widget_id}`]
+      }
+      if (context?.mobilization_id) {
+        categories = [...categories, `autofire-m${context?.mobilization_id}`]
+      }
+      if (context?.community_id) {
+        categories = [...categories, `autofire-c${context?.community_id}`]
+      }
     }
-    if (context?.mobilization_id) {
-      categories = [...categories, `m${context?.mobilization_id}`]
-    }
-    if (context?.community_id) {
-      categories = [...categories, `c${context?.community_id}`]
-    }
+
+    logger.child({ categories }).info("Categorized Sendgrid Message");
 
     return {
       ...message,

--- a/packages/notifications/src/graphql-api/resolvers/email_stats.ts
+++ b/packages/notifications/src/graphql-api/resolvers/email_stats.ts
@@ -26,14 +26,19 @@ interface EmailStatsResponse {
 
 interface EmailStatsArgs {
   widget_id: number;
+  category?: string;
 }
 
 
 export default async (_: void, args: EmailStatsArgs): Promise<EmailStatsResponse> => {
+  const { widget_id, category } = args;
   let categories: string[] = [];
 
-  categories.push(`autofire-w${args.widget_id}`);
- 
+  if (category)  {
+    categories.push(`${category}-w${widget_id}`);
+  }  else {
+    categories.push(`w${widget_id}`);
+  }
   const query = {
     bool: {
       must: [

--- a/packages/notifications/src/graphql-api/resolvers/email_stats.ts
+++ b/packages/notifications/src/graphql-api/resolvers/email_stats.ts
@@ -20,6 +20,7 @@ interface EmailStatsResponse {
     bounced: number;
     processed: number;
     click: number;
+    total: number;
   };
 }
 
@@ -79,6 +80,7 @@ export default async (_: void, args: EmailStatsArgs): Promise<EmailStatsResponse
       bounced: events.filter(event => event.event === "bounced").length,
       processed: events.filter(event => event.event === "processed").length,
       click: events.filter(event => event.event === "click").length,
+      total: events.length
     };
 
     return { events, stats };

--- a/packages/notifications/src/graphql-api/resolvers/email_stats.ts
+++ b/packages/notifications/src/graphql-api/resolvers/email_stats.ts
@@ -18,18 +18,43 @@ interface EmailStatsResponse {
 
 interface EmailStatsArgs {
   widget_id: number;
+  mobilization_id?: number;
+  community_id?: number;
 }
 
 
 export default async (_: void, args: EmailStatsArgs): Promise<EmailStatsResponse> => {
+  let categories: string[] = [];
+
+  if (args.widget_id) {
+    categories.push(`autofire-w${args.widget_id}`);
+  }
+  if (args.mobilization_id) {
+    categories.push(`autofire-m${args.mobilization_id}`);
+  }
+  if (args.community_id) {
+    categories.push(`autofire-c${args.community_id}`);
+  }
+
   const query = {
     bool: {
-      should: [
-        { match: { event: "delivered" } },
-        { match: { event: "bounced" } },
-        { match: { event: "processed" } },
-        { match: { event: "click" } },
-        { match: { event: "open" } }
+      must: [
+        {
+          terms: {
+            category: categories
+          }
+        },
+        {
+          bool: {
+            should: [
+              { match: { event: "delivered" } },
+              { match: { event: "bounced" } },
+              { match: { event: "processed" } },
+              { match: { event: "click" } },
+              { match: { event: "open" } }
+            ]
+          }
+        }
       ]
     }
   };

--- a/packages/notifications/src/graphql-api/resolvers/email_stats.ts
+++ b/packages/notifications/src/graphql-api/resolvers/email_stats.ts
@@ -14,34 +14,31 @@ interface EmailEvent {
 
 interface EmailStatsResponse {
   events: EmailEvent[];
+  stats: {
+    open: number;
+    delivered: number;
+    bounced: number;
+    processed: number;
+    click: number;
+  };
 }
 
 interface EmailStatsArgs {
   widget_id: number;
-  mobilization_id?: number;
-  community_id?: number;
 }
 
 
 export default async (_: void, args: EmailStatsArgs): Promise<EmailStatsResponse> => {
   let categories: string[] = [];
 
-  if (args.widget_id) {
-    categories.push(`autofire-w${args.widget_id}`);
-  }
-  if (args.mobilization_id) {
-    categories.push(`autofire-m${args.mobilization_id}`);
-  }
-  if (args.community_id) {
-    categories.push(`autofire-c${args.community_id}`);
-  }
-
+  categories.push(`autofire-w${args.widget_id}`);
+ 
   const query = {
     bool: {
       must: [
         {
           terms: {
-            category: categories
+            "category.keyword": categories
           }
         },
         {
@@ -73,10 +70,18 @@ export default async (_: void, args: EmailStatsArgs): Promise<EmailStatsResponse
       sg_message_id: hit._source.sg_message_id,
       useragent: hit._source.useragent,
       ip: hit._source.ip,
-      url: hit._source.url
+      url: hit._source.url,
     }));
 
-    return { events: events };
+    const stats = {
+      open: events.filter(event => event.event === "open").length,
+      delivered: events.filter(event => event.event === "delivered").length,
+      bounced: events.filter(event => event.event === "bounced").length,
+      processed: events.filter(event => event.event === "processed").length,
+      click: events.filter(event => event.event === "click").length,
+    };
+
+    return { events, stats };
   } catch (error) {
     logger.error(`Failed to fetch email stats`);
     throw new Error(`Failed to fetch email stats`);

--- a/packages/notifications/src/graphql-api/resolvers/email_stats.ts
+++ b/packages/notifications/src/graphql-api/resolvers/email_stats.ts
@@ -1,26 +1,59 @@
 import logger, { apmAgent } from "../../logger";
 import { client } from "../../core/elasticsearchdb";
 
+interface EmailEvent {
+  email: string;
+  event: string;
+  timestamp: number;
+  sg_event_id: string;
+  sg_message_id: string;
+  useragent: string;
+  ip: string;
+  url: string;
+}
+
 interface EmailStatsResponse {
-  message: string
+  events: EmailEvent[];
 }
 
 interface EmailStatsArgs {
-  widget_id: number
+  widget_id: number;
 }
 
 
 export default async (_: void, args: EmailStatsArgs): Promise<EmailStatsResponse> => {
   const query = {
-    match: {
-      category: `autofire`
+    bool: {
+      should: [
+        { match: { event: "delivered" } },
+        { match: { event: "bounced" } },
+        { match: { event: "processed" } },
+        { match: { event: "click" } },
+        { match: { event: "open" } }
+      ]
     }
   };
-  const { statusCode, body } = await client.search({
-    index: "events-sendgrid-*",
-    body: { query: query }
-  });
-  
-  return { message: "Olá Mario e Miguel! Total de eventos filtrados por autofire: " + body.hits.total.value }
-  // throw new Error("Failed elasticsearch with status: " + statusCode);
-}
+
+  try {
+    const { body } = await client.search({
+      index: "events-sendgrid-*",
+      body: { query: query }
+    });
+
+    const events = body.hits.hits.map((hit: any) => ({
+      email: hit._source.email,
+      event: hit._source.event,
+      timestamp: hit._source.timestamp,
+      sg_event_id: hit._source.sg_event_id,
+      sg_message_id: hit._source.sg_message_id,
+      useragent: hit._source.useragent,
+      ip: hit._source.ip,
+      url: hit._source.url
+    }));
+
+    return { events: events };
+  } catch (error) {
+    logger.error(`Failed to fetch email stats`);
+    throw new Error(`Failed to fetch email stats`);
+  }
+};

--- a/packages/notifications/src/graphql-api/resolvers/email_stats.ts
+++ b/packages/notifications/src/graphql-api/resolvers/email_stats.ts
@@ -1,0 +1,26 @@
+import logger, { apmAgent } from "../../logger";
+import { client } from "../../core/elasticsearchdb";
+
+interface EmailStatsResponse {
+  message: string
+}
+
+interface EmailStatsArgs {
+  widget_id: number
+}
+
+
+export default async (_: void, args: EmailStatsArgs): Promise<EmailStatsResponse> => {
+  const query = {
+    match: {
+      category: `autofire`
+    }
+  };
+  const { statusCode, body } = await client.search({
+    index: "events-sendgrid-*",
+    body: { query: query }
+  });
+  
+  return { message: "Olá Mario e Miguel! Total de eventos filtrados por autofire: " + body.hits.total.value }
+  // throw new Error("Failed elasticsearch with status: " + statusCode);
+}

--- a/packages/notifications/src/graphql-api/resolvers/index.ts
+++ b/packages/notifications/src/graphql-api/resolvers/index.ts
@@ -3,12 +3,14 @@ import notify from './notify';
 import activity_feed from "./activity_feed";
 import activity_feed_total from './activity_feed_total';
 import activity_feed_timestamp from "./activity_feed_timestamp";
+import email_stats from './email_stats';
 
 const resolverMap = {
   Query: {
     activity_feed,
     activity_feed_total,
-    activity_feed_timestamp
+    activity_feed_timestamp,
+    email_stats
   },
   Mutation: {
     notify

--- a/packages/notifications/src/graphql-api/schema/schema.graphql
+++ b/packages/notifications/src/graphql-api/schema/schema.graphql
@@ -61,10 +61,16 @@ type ActivityFeedTimestampResponse {
   max_timestamp: Int
 }
 
+type EmailStatsResponse {
+  message: String
+}
+
 type Query {
   activity_feed(filter: ActivityFeedFilter): ActivityFeedResponse
   activity_feed_total(widget_id: Int!): ActivityFeedTotalResponse
   activity_feed_timestamp: ActivityFeedTimestampResponse
+
+  email_stats(widget_id: Int!): EmailStatsResponse
 }
 
 type Mutation {

--- a/packages/notifications/src/graphql-api/schema/schema.graphql
+++ b/packages/notifications/src/graphql-api/schema/schema.graphql
@@ -72,8 +72,17 @@ type EmailEvent {
   url: String
 }
 
+type EmailStats {
+  open: Int
+  delivered: Int
+  bounced: Int
+  processed: Int
+  click: Int
+}
+
 type EmailStatsResponse {
   events: [EmailEvent]
+  stats: EmailStats
 }
 
 type Query {

--- a/packages/notifications/src/graphql-api/schema/schema.graphql
+++ b/packages/notifications/src/graphql-api/schema/schema.graphql
@@ -78,6 +78,7 @@ type EmailStats {
   bounced: Int
   processed: Int
   click: Int
+  total: Int
 }
 
 type EmailStatsResponse {

--- a/packages/notifications/src/graphql-api/schema/schema.graphql
+++ b/packages/notifications/src/graphql-api/schema/schema.graphql
@@ -61,8 +61,19 @@ type ActivityFeedTimestampResponse {
   max_timestamp: Int
 }
 
+type EmailEvent {
+  email: String
+  event: String
+  timestamp: Int
+  sg_event_id: String
+  sg_message_id: String
+  useragent: String
+  ip: String
+  url: String
+}
+
 type EmailStatsResponse {
-  message: String
+  events: [EmailEvent]
 }
 
 type Query {

--- a/packages/notifications/src/graphql-api/schema/schema.graphql
+++ b/packages/notifications/src/graphql-api/schema/schema.graphql
@@ -91,7 +91,7 @@ type Query {
   activity_feed_total(widget_id: Int!): ActivityFeedTotalResponse
   activity_feed_timestamp: ActivityFeedTimestampResponse
 
-  email_stats(widget_id: Int!): EmailStatsResponse
+  email_stats(widget_id: Int!, category: String): EmailStatsResponse
 }
 
 type Mutation {


### PR DESCRIPTION
# Contexto
Os e-mails são enviados usando a plataforma do Sendgrid, atualmente temos um webhook conectado ao Sendgrid para coletar informações estatisiticas da pressão por e-mail e salva-las no ElasticSearch. Dessa forma, criamos novos resolvers na API GraphQL de Notificações para retornar dados quantitativos referentes aos eventos armazenados no ElasticCloud.


# Asana
[Como mobilizador, quero visualizar os indicadores de entrega desse e-mail no BONDE](https://app.asana.com/0/1161468210277385/1207532979862268/f)
- [x] [Criar categorias para mapear pós-ação (autofire)](https://app.asana.com/0/1161468210277385/1207534015055352/f)
- [x] [Criar métodos GraphQL na API de Notificações para informar dados estatísticos](https://app.asana.com/0/1161468210277385/1207554288545334/f)
- [x] [Criar interface para visualizar os dados de abertura de e-mail](https://app.asana.com/0/1161468210277385/1207554343969209/f)

# Layout
![Autofire04](https://github.com/nossas/bonde-apis/assets/2698516/a9a33358-f3e7-4c9f-8583-f1fdce082959)


#Screenshots
<img width="1320" alt="Captura de Tela 2024-06-26 às 14 59 39" src="https://github.com/nossas/bonde-apis/assets/2698516/c9b3458a-209f-4dad-b78e-352ce8eb543e">

