### PR TITLE
fix(github-workflow): update tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,14 @@ jobs:
           GRAPHQL_HTTP_URL: http://bonde.devel/graphql
         run: pnpm test
       
+      - name: Wait before uploading coverage
+          run: sleep 30s
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          directory: ./coverage
+          files: ./coverage/lcov.info
           flags: unittests
           verbose: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
# Contexto
Está acontecendo um erro no GitHub Actions é devido ao limite de taxa atingido no Codecov, conforme a mensagem de erro:
`Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 429 - {'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 1854s.', code='throttled')}`

## Exemplo
[Build and push docker image](https://github.com/nossas/bonde-apis/actions/runs/9518059562/job/26238047919#step:5:318)

# Solução

1. Inserido _sleep_ para fazer um pequeno atraso antes do upload pode ajudar a evitar o limite de taxa.
2. Atualizei a configuração para especificar diretamente o arquivo lcov.info

```
- name: Wait before uploading coverage
  run: sleep 30s

- name: Upload coverage to Codecov
  uses: codecov/codecov-action@v2
  with:
    token: ${{ secrets.CODECOV_TOKEN }}
    fail_ci_if_error: true
    files: ./coverage/lcov.info
    flags: unittests
    verbose: true
```