### PR TITLE
fix(an-web): update typings to accept json without field

### DIFF
--- a/action-network/Dockerfile
+++ b/action-network/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 WORKDIR /code
 

--- a/action-network/web/main.py
+++ b/action-network/web/main.py
@@ -13,7 +13,6 @@ from normalize import to_payload
 app = FastAPI()
 
 @app.post("/webhook/activist_action")
-
 async def webhook_activist_action(body: Payload):
     """Webhook for integration Bonde activist actions to Action Network"""
     # Normalize hasura event payload

--- a/action-network/web/typings.py
+++ b/action-network/web/typings.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional
 from pydantic import BaseModel, Field
 
 
@@ -23,8 +23,8 @@ class FormData(BaseModel):
     lastname: str
     body: str
     name: str
-    state: Union[str, None]
-    phone: Union[str, None]
+    state: Optional[str] = None
+    phone: Optional[str] = None
 
 class Pressure(WidgetAction):
     """Represents widget pressure model"""
@@ -34,9 +34,9 @@ class PlipFormData(BaseModel):
     """Represents plip form data"""
     email: str
     state: str
-    color: Union[str, None]
-    whatsapp: Union[str, None]
-    gender: Union[str, None]
+    color: Optional[str] = None
+    whatsapp: Optional[str] = None
+    gender: Optional[str] = None
     name: str
     expected_signatures: int
 
@@ -58,16 +58,16 @@ class Address(BaseModel):
     city: str
     street_number: str
     neighborhood: str
-    complementary: Union[str, None]
+    complementary: Optional[str] = None
 
 
 class CheckoutData(BaseModel):
     """CheckoutData"""
     email: str
-    phone: Union[Phone, None]
+    phone: Optional[Phone] = None
     document_number: str
     name: str
-    address: Union[Address, None]
+    address: Optional[Address] = None
 
 
 class Donation(WidgetAction):
@@ -81,7 +81,7 @@ class Donation(WidgetAction):
 
 class Data(BaseModel):
     """Hasura Data Model"""
-    new: Union[Donation, Form, Pressure, Plip]
+    new: Pressure | Plip | Donation | Form
 
 
 class Event(BaseModel):


### PR DESCRIPTION
**Contexto**
Haviam entradas inválidas na API de Normalização, isso acontecia por existir um campo JSON em determinadas tabelas de ações que podem ter diferentes estruturas, o Pydantic não estava considerando que o campo poderia não existir no JSON, apenas que deveria existir mas com valor nulo, como isso não é uma verdade e tem casos que o campo não existe foi preciso forçar valores que podem ser nulo diretamente no Pydantic.