### PR TITLE
Feature/migrate ip to load balancer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apk add --no-cache \
     build-base \
     python3
 
-RUN yarn global add pnpm node-gyp
+# Pnpm version 10
+# node-gyp version 11
+RUN yarn global add pnpm@10 node-gyp@11
 
 COPY package*.json ./
 

--- a/packages/accounts-api/env.d.ts
+++ b/packages/accounts-api/env.d.ts
@@ -5,6 +5,12 @@ declare namespace NodeJS {
     LOG_LEVEL?: string
     GRAPHQL_HTTP_URL: string
     JWT_SECRET: string
+    JWT_TOKEN?: string
     HASURA_SECRET?: string
+    AWS_ACCESS_KEY?: string
+    AWS_SECRET_KEY?: string
+    AWS_ROUTE53_REGION?: string
+    AWS_LOAD_BALANCER_DNS?: string
+    AWS_LOAD_BALANCER_HOSTED_ZONE_ID?: string
   }
 }

--- a/packages/domains-api/src/config/config.ts
+++ b/packages/domains-api/src/config/config.ts
@@ -28,8 +28,8 @@ const config: Config = {
   awsAccessKey: process.env.AWS_ACCESS_KEY,
   awsSecretKey: process.env.AWS_SECRET_KEY,
   awsRoute53Region: process.env.AWS_ROUTE53_REGION || 'sa-east-1',
-  awsLoadBalancerDns: process.env.AWS_LOAD_BALANCER_DNS || 'a2f212cad2d294747a445a1c3912809d-d2f26ccca140a83f.elb.us-east-1.amazonaws.com.',
-  awsLoadBalancerHostedZoneId: process.env.AWS_LOAD_BALANCER_HOSTED_ZONE_ID || 'Z35SXDOTRQ7X7K'
+  awsLoadBalancerDns: process.env.AWS_LOAD_BALANCER_DNS || 'localhost',
+  awsLoadBalancerHostedZoneId: process.env.AWS_LOAD_BALANCER_HOSTED_ZONE_ID || 'localhost'
 };
 
 export default config;

--- a/packages/domains-api/src/config/config.ts
+++ b/packages/domains-api/src/config/config.ts
@@ -13,7 +13,8 @@ type Config = {
   awsAccessKey?: string
   awsSecretKey?: string
   awsRoute53Region: string
-  awsRouteIp: string
+  awsLoadBalancerDns: string
+  awsLoadBalancerHostedZoneId: string
 }
 
 const config: Config = {
@@ -27,7 +28,8 @@ const config: Config = {
   awsAccessKey: process.env.AWS_ACCESS_KEY,
   awsSecretKey: process.env.AWS_SECRET_KEY,
   awsRoute53Region: process.env.AWS_ROUTE53_REGION || 'sa-east-1',
-  awsRouteIp: process.env.AWS_ROUTE_IP || 'localhost'
+  awsLoadBalancerDns: process.env.AWS_LOAD_BALANCER_DNS || 'a2f212cad2d294747a445a1c3912809d-d2f26ccca140a83f.elb.us-east-1.amazonaws.com.',
+  awsLoadBalancerHostedZoneId: process.env.AWS_LOAD_BALANCER_HOSTED_ZONE_ID || 'Z35SXDOTRQ7X7K'
 };
 
 export default config;

--- a/packages/domains-api/src/route53/create_default_records.ts
+++ b/packages/domains-api/src/route53/create_default_records.ts
@@ -1,39 +1,45 @@
 import config from '../config/config';
-import logger from '../config/logger'
+import logger from '../config/logger';
+
+type AliasTarget = {
+  DNSName: string;
+  EvaluateTargetHealth: boolean;
+  HostedZoneId: string;
+};
 
 type ResourceRecord = {
-  Value: string
-}
+  Value: string;
+};
 
 type ResourceRecordSet = {
-  Name: string
-  ResourceRecords: ResourceRecord[]
-  TTL: number
-  Type: string
-}
+  Name: string;
+  ResourceRecords?: ResourceRecord[];
+  AliasTarget?: AliasTarget;
+  TTL?: number;
+  Type: string;
+};
 
 type Change = {
-  Action: string
-  ResourceRecordSet: ResourceRecordSet
-}
+  Action: string;
+  ResourceRecordSet: ResourceRecordSet;
+};
 
 type ChangeBatch = {
-  Changes: Change[]
-  Comment: string
-}
+  Changes: Change[];
+  Comment: string;
+};
 
 type RecordParams = {
-  ChangeBatch: ChangeBatch
-  HostedZoneId: string
-}
+  ChangeBatch: ChangeBatch;
+  HostedZoneId: string;
+};
 
 type Args = {
-  domain: string
-  hostedZoneId: string
-}
+  domain: string;
+  hostedZoneId: string;
+};
 
 export default (route53: any) => async ({ domain, hostedZoneId }: Args) => {
-  // Create defaults Record on AWS
   const records: RecordParams = {
     ChangeBatch: {
       Changes: [
@@ -41,36 +47,39 @@ export default (route53: any) => async ({ domain, hostedZoneId }: Args) => {
           Action: 'CREATE',
           ResourceRecordSet: {
             Name: domain,
-            ResourceRecords: [
-              { Value: config.awsRouteIp }
-            ],
-            TTL: 300,
-            Type: 'A'
+            Type: 'A',
+            AliasTarget: {
+              DNSName: config.awsLoadBalancerDns,
+              EvaluateTargetHealth: true,
+              HostedZoneId: config.awsLoadBalancerHostedZoneId
+            }
           }
         },
         {
           Action: 'CREATE',
           ResourceRecordSet: {
-            Name: `*.${domain}`,
+            Name: `*.${domain}`, 
             ResourceRecords: [
-              { Value: config.awsRouteIp }
+              { Value: config.awsLoadBalancerDns }
             ],
             TTL: 300,
-            Type: 'A'
+            Type: 'CNAME'
           }
         }
       ],
       Comment: 'autocreated'
     },
     HostedZoneId: hostedZoneId
-  }
-  logger.child({ records }).info('changeResourceRecordSets');
+  };
 
+  logger.child({ records }).info('changeResourceRecordSets');
+  
   try {
     const result = await route53.changeResourceRecordSets(records).promise();
-    logger.child({ result }).info('changeResourceRecordSets');
+    logger.child({ result }).info('changeResourceRecordSets - success');
+    return result;
   } catch (err) {
-    logger.child({ err }).info('error');
-    return [];
+    logger.child({ err }).error('changeResourceRecordSets - error');
+    throw err;
   }
-}
+};

--- a/packages/domains-api/src/route53/index.ts
+++ b/packages/domains-api/src/route53/index.ts
@@ -10,7 +10,8 @@ import delete_records from './delete_records';
 if (!config.awsAccessKey) throw new Error('AWS_ACCESS_KEY not found');
 if (!config.awsSecretKey) throw new Error('AWS_SECRET_KEY not found');
 
-if (!config.awsRouteIp) throw new Error('AWS_ROUTE_IP not found');
+if (!config.awsLoadBalancerDns) throw new Error('AWS_LOAD_BALANCER_DNS not found');
+if (!config.awsLoadBalancerHostedZoneId) throw new Error('AWS_LOAD_BALANCER_HOSTED_ZONE_ID not found');
 
 // Configure AWS
 AWS.config.update({


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
Para remover a complexidade de gerenciar certificados, a nova infraestrutura vai passar a usar a funcionalidade on-demand do Caddy, isso vai fazer com que a estrutura API-Router não seja mais necessária.

É necessário remover essa estrutura da plataforma.

## Checklist
- [x] Atualizar valores do Route 53, inves de inserir por IP, pegaremos pelo Load balancer ou CNAME. 
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [[BUG] Problema na hora de cadastrar o domínio na Campanha](https://app.asana.com/1/1105567501435500/task/1212459891425493) 
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Notas de deploy
<!-- Notas de deploy do desenvolvimento da aplicação. Devem ser novas dependências, scripts, etc. -->
Para que a implementação funcione é necessário atualizar o arquivo .env com as seguintes variaveis:

```
# AWS Configuration
AWS_ACCESS_KEY=aws_access_key
AWS_SECRET_KEY=aws_secret_key
AWS_ROUTE53_REGION=us-east-1

# Load Balancer Configuration
AWS_LOAD_BALANCER_DNS=a2f2*************.
AWS_LOAD_BALANCER_HOSTED_ZONE_ID=Z35SXDOTRQ7X7K
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212459891425493